### PR TITLE
Created distribution package transpiled to ES5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [["@babel/preset-env"]],
+  "plugins": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,37 @@
+'use strict';
+/* eslint-disable no-mixed-operators */
+
+module.exports = function (red, green, blue, alpha) {
+  var isPercent = (red + (alpha || '')).toString().includes('%');
+
+  if (typeof red === 'string') {
+    var res = red.match(/(0?\.?\d{1,3})%?\b/g).map(Number); // TODO: use destructuring when targeting Node.js 6
+
+    red = res[0];
+    green = res[1];
+    blue = res[2];
+    alpha = res[3];
+  } else if (alpha !== undefined) {
+    alpha = parseFloat(alpha);
+  }
+
+  if (typeof red !== 'number' || typeof green !== 'number' || typeof blue !== 'number' || red > 255 || green > 255 || blue > 255) {
+    throw new TypeError('Expected three numbers below 256');
+  }
+
+  if (typeof alpha === 'number') {
+    if (!isPercent && alpha >= 0 && alpha <= 1) {
+      alpha = Math.round(255 * alpha);
+    } else if (isPercent && alpha >= 0 && alpha <= 100) {
+      alpha = Math.round(255 * alpha / 100);
+    } else {
+      throw new TypeError("Expected alpha value (".concat(alpha, ") as a fraction or percentage"));
+    }
+
+    alpha = (alpha | 1 << 8).toString(16).slice(1);
+  } else {
+    alpha = '';
+  }
+
+  return (blue | green << 8 | red << 16 | 1 << 24).toString(16).slice(1) + alpha;
+};

--- a/package.json
+++ b/package.json
@@ -12,12 +12,20 @@
   "engines": {
     "node": ">=4"
   },
+  "browserslist": [
+    "last 1 version",
+    "> 1%",
+    "maintained node versions",
+    "not dead"
+  ],
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava",
+    "build": "babel index.js --out-dir dist"
   },
   "files": [
     "index.js"
   ],
+  "main": "dist/index.js",
   "keywords": [
     "rgb",
     "hex",
@@ -28,6 +36,9 @@
     "converter"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.1.2",
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
     "ava": "*",
     "xo": "*"
   },


### PR DESCRIPTION
Some projects would not compile with ES6-specific code like `const` keyword. I've added a distribution folder with a transpiled bundle via Babel env.